### PR TITLE
Use the filesize on disk to populate the size in feed

### DIFF
--- a/src/classes/Episode.php
+++ b/src/classes/Episode.php
@@ -12,6 +12,7 @@
 		public string $duration;
 		public string $guid;
 		public string $directLink;
+		public int $size;
 		
 		public function __construct (
 			string $title = "",
@@ -20,7 +21,8 @@
 			string $pubDate = "",
 			string $duration = "",
 			string $guid = "",
-			string $directLink = ""
+			string $directLink = "",
+			int $size = 0
 		) {
 			$this->title = $title;
 			$this->link = $link;
@@ -29,5 +31,6 @@
 			$this->duration = $duration;
 			$this->guid = $guid;
 			$this->directLink = $directLink;
+			$this->size = $size;
 		}
 	}

--- a/src/index.php
+++ b/src/index.php
@@ -118,6 +118,9 @@
 			secho("Exception: " . $e->getMessage());
 		}
 		
+		$episodeObject->size = filesize('podcasts/' . $episodeObject->guid . ".mp3");
+		$itemDummy = str_replace("{{{FILESIZE}}}", $episodeObject->size, $itemDummy);
+
 		if ($i == 0) {
 			$feed = str_replace("{{{PUBDATE}}}", $episodeObject->pubDate, $feed);
 		}

--- a/src/tmp/item_dummy.xml
+++ b/src/tmp/item_dummy.xml
@@ -6,7 +6,7 @@
             <itunes:image href="https://ssl-static.libsyn.com/p/assets/a/c/9/a/ac9a07211ef7a827/VGOlogoArt.jpg" />
             <description><![CDATA[<p>{{{DESCRIPTION}}}</p>]]></description>
             <content:encoded><![CDATA[<p>{{{DESCRIPTION}}}</p>]]></content:encoded>
-            <enclosure length="116273564" type="audio/mpeg" url="{{{DIRECT_LINK}}}" />
+            <enclosure length="{{{FILESIZE}}}" type="audio/mpeg" url="{{{DIRECT_LINK}}}" />
             <itunes:duration>{{{DURATION}}}</itunes:duration>
             <itunes:explicit>no</itunes:explicit>
             <itunes:keywords />


### PR DESCRIPTION
I tried to see if I could find the file size in the scraped data with no luck, so I just check the size of the downloaded file. I couldn't do the `str_replace` in the same spot as the rest of them because it needs the file to be downloaded first, if you'd like I can move the file download to be before populating the `itemDummy` so they are all in the same spot, or you decide to merge as is.