### PR TITLE
Update LibsynJSONGrabber to handle a change in the incoming JSON feed date format

### DIFF
--- a/src/classes/Episode.php
+++ b/src/classes/Episode.php
@@ -22,7 +22,7 @@
 			private string $podcastFilePath,
 			public string $downloadLink
 		) {
-			$this->guid = sha1($this->pubDate->format("d-m-y h:i") . $this->title);
+			$this->guid = sha1($this->pubDate->format("d-m-y") . $this->title);
 			$this->directLink = $this->podcastFilePath . $this->guid . "." . $this->ext;
 		}
 	}

--- a/src/classes/LibsynJSONGrabber.php
+++ b/src/classes/LibsynJSONGrabber.php
@@ -50,7 +50,7 @@
 					title: $episode->item_title,
 					link: $episode->permalink_url,
 					description: $episode->item_subtitle,
-					pubDate: new DateTime($episode->release_date),
+					pubDate: DateTime::createFromFormat('M/d/Y', $episode->release_date),
 					duration: $episode->duration,
 					ext: $episode->ext,
 					podcastFilePath: $this->podcastFileLocation,


### PR DESCRIPTION
LibSyn changed the date format used in the JSON feed, this change handles that. Resolves #6.